### PR TITLE
Adds 'AirBuilderWithPublicValues' trait and support for using public values when proving/verifying

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -109,9 +109,7 @@ pub trait AirBuilder: Sized {
 }
 
 pub trait AirBuilderWithPublicValues: AirBuilder {
-    type PublicVar: Into<Self::Expr> + Copy;
-
-    fn public_values(&self) -> &[Self::PublicVar];
+    fn public_values(&self) -> Self::M;
 }
 
 pub trait PairBuilder: AirBuilder {

--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -109,7 +109,9 @@ pub trait AirBuilder: Sized {
 }
 
 pub trait AirBuilderWithPublicValues: AirBuilder {
-    fn public_values(&self) -> &[Self::F];
+    type PublicVar: Into<Self::Expr> + Copy;
+
+    fn public_values(&self) -> &[Self::PublicVar];
 }
 
 pub trait PairBuilder: AirBuilder {

--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -108,6 +108,10 @@ pub trait AirBuilder: Sized {
     }
 }
 
+pub trait AirBuilderWithPublicValues: AirBuilder {
+    fn public_values(&self) -> &[Self::F];
+}
+
 pub trait PairBuilder: AirBuilder {
     fn preprocessed(&self) -> Self::M;
 }

--- a/air/src/virtual_column.rs
+++ b/air/src/virtual_column.rs
@@ -55,6 +55,16 @@ impl<F: Field> VirtualPairCol<F> {
         )
     }
 
+    pub fn new_public(column_weights: Vec<(usize, F)>, constant: F) -> Self {
+        Self::new(
+            column_weights
+                .into_iter()
+                .map(|(i, w)| (PairCol::Public(i), w))
+                .collect(),
+            constant,
+        )
+    }
+
     #[must_use]
     pub fn one() -> Self {
         Self::constant(F::one())
@@ -87,6 +97,11 @@ impl<F: Field> VirtualPairCol<F> {
     }
 
     #[must_use]
+    pub fn single_public(column: usize) -> Self {
+        Self::single(PairCol::Public(column))
+    }
+
+    #[must_use]
     pub fn sum_main(columns: Vec<usize>) -> Self {
         let column_weights = columns.into_iter().map(|col| (col, F::one())).collect();
         Self::new_main(column_weights, F::zero())
@@ -96,6 +111,12 @@ impl<F: Field> VirtualPairCol<F> {
     pub fn sum_preprocessed(columns: Vec<usize>) -> Self {
         let column_weights = columns.into_iter().map(|col| (col, F::one())).collect();
         Self::new_preprocessed(column_weights, F::zero())
+    }
+
+    #[must_use]
+    pub fn sum_public(columns: Vec<usize>) -> Self {
+        let column_weights = columns.into_iter().map(|col| (col, F::one())).collect();
+        Self::new_public(column_weights, F::zero())
     }
 
     /// `a - b`, where `a` and `b` are columns in the preprocessed trace.
@@ -108,6 +129,12 @@ impl<F: Field> VirtualPairCol<F> {
     #[must_use]
     pub fn diff_main(a_col: usize, b_col: usize) -> Self {
         Self::new_main(vec![(a_col, F::one()), (b_col, F::neg_one())], F::zero())
+    }
+
+    /// `a - b`, where `a` and `b` are columns in the main trace.
+    #[must_use]
+    pub fn diff_public(a_col: usize, b_col: usize) -> Self {
+        Self::new_public(vec![(a_col, F::one()), (b_col, F::neg_one())], F::zero())
     }
 
     pub fn apply<Expr, Var>(&self, preprocessed: &[Var], public: &[Var], main: &[Var]) -> Expr

--- a/air/src/virtual_column.rs
+++ b/air/src/virtual_column.rs
@@ -13,14 +13,16 @@ pub struct VirtualPairCol<F: Field> {
 /// A column in a PAIR, i.e. either a preprocessed column or a main trace column.
 pub enum PairCol {
     Preprocessed(usize),
+    Public(usize),
     Main(usize),
 }
 
 impl PairCol {
-    fn get<T: Copy>(&self, preprocessed: &[T], main: &[T]) -> T {
+    fn get<T: Copy>(&self, preprocessed: &[T], public: &[T], main: &[T]) -> T {
         match self {
             PairCol::Preprocessed(i) => preprocessed[*i],
             PairCol::Main(i) => main[*i],
+            PairCol::Public(i) => public[*i],
         }
     }
 }
@@ -108,7 +110,7 @@ impl<F: Field> VirtualPairCol<F> {
         Self::new_main(vec![(a_col, F::one()), (b_col, F::neg_one())], F::zero())
     }
 
-    pub fn apply<Expr, Var>(&self, preprocessed: &[Var], main: &[Var]) -> Expr
+    pub fn apply<Expr, Var>(&self, preprocessed: &[Var], public: &[Var], main: &[Var]) -> Expr
     where
         F: Into<Expr>,
         Expr: AbstractField + Mul<F, Output = Expr>,
@@ -116,7 +118,7 @@ impl<F: Field> VirtualPairCol<F> {
     {
         let mut result = self.constant.into();
         for (column, weight) in &self.column_weights {
-            result += column.get(preprocessed, main).into() * *weight;
+            result += column.get(preprocessed, public, main).into() * *weight;
         }
         result
     }

--- a/commit/src/pcs.rs
+++ b/commit/src/pcs.rs
@@ -3,6 +3,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::Debug;
+use p3_matrix::dense::RowMajorMatrix;
 
 use p3_challenger::FieldChallenger;
 use p3_field::{ExtensionField, Field};
@@ -77,8 +78,6 @@ where
     where
         Self: 'a;
 
-    type LdeOwned: MatrixRows<Val> + MatrixGet<Val> + Sync;
-
     fn coset_shift(&self) -> Val;
 
     fn log_blowup(&self) -> usize;
@@ -88,16 +87,17 @@ where
         'a: 'b;
 
     // Compute the (shifted) low-degree extensions only without computing the commitment.
-    fn compute_ldes_batches(
+    fn compute_coset_ldes_batches(
         &self,
         polynomials: Vec<In>,
-        coset_shifts: &[Val],
-    ) -> Vec<Self::LdeOwned>;
+        coset_shifts: Vec<Val>,
+    ) -> Vec<RowMajorMatrix<Val>>;
 
-    fn compute_lde_batch(&self, polynomials: In, coset_shift: Val) -> Vec<Self::LdeOwned> {
-        self.compute_ldes_batches(vec![polynomials], &[coset_shift])
+    fn compute_lde_batch(&self, polynomials: In) -> RowMajorMatrix<Val> {
+        self.compute_coset_ldes_batches(vec![polynomials], vec![Val::one()])
+            .pop()
+            .expect("length of output of compute_coset_ldes_batches should be the same as length of the input")
     }
-
     // Commit to polys that are already defined over a coset.
     fn commit_shifted_batches(
         &self,

--- a/commit/src/pcs.rs
+++ b/commit/src/pcs.rs
@@ -77,6 +77,8 @@ where
     where
         Self: 'a;
 
+    type LdeOwned: MatrixRows<Val> + MatrixGet<Val> + Sync;
+
     fn coset_shift(&self) -> Val;
 
     fn log_blowup(&self) -> usize;
@@ -84,6 +86,17 @@ where
     fn get_ldes<'a, 'b>(&'a self, prover_data: &'b Self::ProverData) -> Vec<Self::Lde<'b>>
     where
         'a: 'b;
+
+    // Compute the (shifted) low-degree extensions only without computing the commitment.
+    fn compute_ldes_batches(
+        &self,
+        polynomials: Vec<In>,
+        coset_shifts: &[Val],
+    ) -> Vec<Self::LdeOwned>;
+
+    fn compute_lde_batch(&self, polynomials: In, coset_shift: Val) -> Vec<Self::LdeOwned> {
+        self.compute_ldes_batches(vec![polynomials], &[coset_shift])
+    }
 
     // Commit to polys that are already defined over a coset.
     fn commit_shifted_batches(

--- a/keccak-air/examples/prove_baby_bear_keccak.rs
+++ b/keccak-air/examples/prove_baby_bear_keccak.rs
@@ -69,8 +69,8 @@ fn main() -> Result<(), VerificationError> {
 
     let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
     let trace = generate_trace_rows::<Val>(inputs);
-    let proof = prove::<MyConfig, _>(&config, &KeccakAir {}, &mut challenger, trace);
+    let proof = prove::<MyConfig, _>(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
 
     let mut challenger = Challenger::new(perm);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof)
+    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
 }

--- a/keccak-air/examples/prove_baby_bear_poseidon2.rs
+++ b/keccak-air/examples/prove_baby_bear_poseidon2.rs
@@ -69,8 +69,8 @@ fn main() -> Result<(), VerificationError> {
 
     let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
     let trace = generate_trace_rows::<Val>(inputs);
-    let proof = prove::<MyConfig, _>(&config, &KeccakAir {}, &mut challenger, trace);
+    let proof = prove::<MyConfig, _>(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
 
     let mut challenger = Challenger::new(perm);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof)
+    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
 }

--- a/keccak-air/examples/prove_goldilocks_keccak.rs
+++ b/keccak-air/examples/prove_goldilocks_keccak.rs
@@ -68,8 +68,8 @@ fn main() -> Result<(), VerificationError> {
 
     let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
     let trace = generate_trace_rows::<Val>(inputs);
-    let proof = prove::<MyConfig, _>(&config, &KeccakAir {}, &mut challenger, trace);
+    let proof = prove::<MyConfig, _>(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
 
     let mut challenger = Challenger::new(perm);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof)
+    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
 }

--- a/uni-stark/src/check_constraints.rs
+++ b/uni-stark/src/check_constraints.rs
@@ -1,5 +1,3 @@
-use alloc::vec::Vec;
-
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, TwoRowMatrixView};
 use p3_field::Field;
 use p3_matrix::dense::RowMajorMatrix;
@@ -7,8 +5,11 @@ use p3_matrix::{Matrix, MatrixRowSlices};
 use tracing::instrument;
 
 #[instrument(name = "check constraints", skip_all)]
-pub(crate) fn check_constraints<F, A>(air: &A, main: &RowMajorMatrix<F>, public_values: &Vec<F>)
-where
+pub(crate) fn check_constraints<F, A>(
+    air: &A,
+    main: &RowMajorMatrix<F>,
+    public_values: &RowMajorMatrix<F>,
+) where
     F: Field,
     A: for<'a> Air<DebugConstraintBuilder<'a, F>>,
 {
@@ -22,6 +23,13 @@ where
         let main = TwoRowMatrixView {
             local: main_local,
             next: main_next,
+        };
+
+        let public_local = main.row_slice(i);
+        let public_next = main.row_slice(i_next);
+        let public_values = TwoRowMatrixView {
+            local: public_local,
+            next: public_next,
         };
 
         let mut builder = DebugConstraintBuilder {
@@ -42,7 +50,7 @@ where
 pub struct DebugConstraintBuilder<'a, F: Field> {
     row_index: usize,
     main: TwoRowMatrixView<'a, F>,
-    public_values: &'a [F],
+    public_values: TwoRowMatrixView<'a, F>,
     is_first_row: F,
     is_last_row: F,
     is_transition: F,
@@ -98,9 +106,7 @@ where
 }
 
 impl<'a, F: Field> AirBuilderWithPublicValues for DebugConstraintBuilder<'a, F> {
-    type PublicVar = F;
-
-    fn public_values(&self) -> &[Self::PublicVar] {
+    fn public_values(&self) -> Self::M {
         self.public_values
     }
 }

--- a/uni-stark/src/check_constraints.rs
+++ b/uni-stark/src/check_constraints.rs
@@ -98,7 +98,9 @@ where
 }
 
 impl<'a, F: Field> AirBuilderWithPublicValues for DebugConstraintBuilder<'a, F> {
-    fn public_values(&self) -> &[Self::F] {
+    type PublicVar = F;
+
+    fn public_values(&self) -> &[Self::PublicVar] {
         self.public_values
     }
 }

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -58,6 +58,8 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolder<'a, SC> {
 }
 
 impl<'a, SC: StarkGenericConfig> AirBuilderWithPublicValues for ProverConstraintFolder<'a, SC> {
+    type PublicVar = Self::F;
+
     fn public_values(&self) -> &[Self::F] {
         self.public_values
     }
@@ -96,6 +98,8 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolder<'a, SC>
     }
 }
 impl<'a, SC: StarkGenericConfig> AirBuilderWithPublicValues for VerifierConstraintFolder<'a, SC> {
+    type PublicVar = Self::F;
+
     fn public_values(&self) -> &[Self::F] {
         self.public_values
     }

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -1,4 +1,3 @@
-use alloc::vec::Vec;
 use p3_air::{AirBuilder, AirBuilderWithPublicValues, TwoRowMatrixView};
 use p3_field::AbstractField;
 
@@ -6,7 +5,7 @@ use crate::{PackedChallenge, PackedVal, StarkGenericConfig};
 
 pub struct ProverConstraintFolder<'a, SC: StarkGenericConfig> {
     pub main: TwoRowMatrixView<'a, PackedVal<SC>>,
-    pub public_values: &'a Vec<SC::Val>,
+    pub public_values: TwoRowMatrixView<'a, PackedVal<SC>>,
     pub is_first_row: PackedVal<SC>,
     pub is_last_row: PackedVal<SC>,
     pub is_transition: PackedVal<SC>,
@@ -16,7 +15,7 @@ pub struct ProverConstraintFolder<'a, SC: StarkGenericConfig> {
 
 pub struct VerifierConstraintFolder<'a, SC: StarkGenericConfig> {
     pub main: TwoRowMatrixView<'a, SC::Challenge>,
-    pub public_values: &'a Vec<SC::Val>,
+    pub public_values: TwoRowMatrixView<'a, SC::Challenge>,
     pub is_first_row: SC::Challenge,
     pub is_last_row: SC::Challenge,
     pub is_transition: SC::Challenge,
@@ -58,9 +57,7 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolder<'a, SC> {
 }
 
 impl<'a, SC: StarkGenericConfig> AirBuilderWithPublicValues for ProverConstraintFolder<'a, SC> {
-    type PublicVar = Self::F;
-
-    fn public_values(&self) -> &[Self::F] {
+    fn public_values(&self) -> Self::M {
         self.public_values
     }
 }
@@ -98,9 +95,7 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolder<'a, SC>
     }
 }
 impl<'a, SC: StarkGenericConfig> AirBuilderWithPublicValues for VerifierConstraintFolder<'a, SC> {
-    type PublicVar = Self::F;
-
-    fn public_values(&self) -> &[Self::F] {
+    fn public_values(&self) -> Self::M {
         self.public_values
     }
 }

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -52,6 +52,7 @@ where
         info_span!("commit to trace data").in_scope(|| pcs.commit_batch(trace));
 
     challenger.observe(trace_commit.clone());
+    challenger.observe_slice(public_values);
     let alpha: SC::Challenge = challenger.sample_ext_element();
 
     let mut trace_ldes = pcs.get_ldes(&trace_data);

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -31,18 +31,19 @@ pub fn prove<
     air: &A,
     challenger: &mut SC::Challenger,
     trace: RowMajorMatrix<SC::Val>,
+    public_values: &Vec<SC::Val>,
 ) -> Proof<SC>
 where
     SC: StarkGenericConfig,
     A: Air<SymbolicAirBuilder<SC::Val>> + for<'a> Air<ProverConstraintFolder<'a, SC>>,
 {
     #[cfg(debug_assertions)]
-    crate::check_constraints::check_constraints(air, &trace);
+    crate::check_constraints::check_constraints(air, &trace, public_values);
 
     let degree = trace.height();
     let log_degree = log2_strict_usize(degree);
 
-    let log_quotient_degree = get_log_quotient_degree::<SC::Val, A>(air);
+    let log_quotient_degree = get_log_quotient_degree::<SC::Val, A>(air, public_values.len());
 
     let g_subgroup = SC::Val::two_adic_generator(log_degree);
 
@@ -63,6 +64,7 @@ where
     let quotient_values = quotient_values(
         config,
         air,
+        public_values,
         log_degree,
         log_quotient_degree,
         trace_lde_for_quotient,
@@ -118,6 +120,7 @@ where
 fn quotient_values<SC, A, Mat>(
     config: &SC,
     air: &A,
+    public_values: &Vec<SC::Val>,
     degree_bits: usize,
     quotient_degree_bits: usize,
     trace_lde: Mat,
@@ -192,6 +195,7 @@ where
                     local: &local,
                     next: &next,
                 },
+                public_values,
                 is_first_row,
                 is_last_row,
                 is_transition,

--- a/uni-stark/src/symbolic_builder.rs
+++ b/uni-stark/src/symbolic_builder.rs
@@ -117,7 +117,9 @@ impl<F: Field> AirBuilder for SymbolicAirBuilder<F> {
 }
 
 impl<F: Field> AirBuilderWithPublicValues for SymbolicAirBuilder<F> {
-    fn public_values(&self) -> &[Self::F] {
+    type PublicVar = F;
+
+    fn public_values(&self) -> &[Self::PublicVar] {
         self.public_values.as_slice()
     }
 }

--- a/uni-stark/src/symbolic_builder.rs
+++ b/uni-stark/src/symbolic_builder.rs
@@ -2,7 +2,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
-use p3_air::{Air, AirBuilder};
+use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues};
 use p3_field::Field;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_util::log2_ceil_usize;
@@ -12,13 +12,13 @@ use crate::symbolic_expression::SymbolicExpression;
 use crate::symbolic_variable::SymbolicVariable;
 
 #[instrument(name = "infer log of constraint degree", skip_all)]
-pub fn get_log_quotient_degree<F, A>(air: &A) -> usize
+pub fn get_log_quotient_degree<F, A>(air: &A, num_public_values: usize) -> usize
 where
     F: Field,
     A: Air<SymbolicAirBuilder<F>>,
 {
     // We pad to at least degree 2, since a quotient argument doesn't make sense with smaller degrees.
-    let constraint_degree = get_max_constraint_degree(air).max(2);
+    let constraint_degree = get_max_constraint_degree(air, num_public_values).max(2);
 
     // The quotient's actual degree is approximately (max_constraint_degree - 1) n,
     // where subtracting 1 comes from division by the zerofier.
@@ -27,25 +27,28 @@ where
 }
 
 #[instrument(name = "infer constraint degree", skip_all, level = "debug")]
-pub fn get_max_constraint_degree<F, A>(air: &A) -> usize
+pub fn get_max_constraint_degree<F, A>(air: &A, num_public_values: usize) -> usize
 where
     F: Field,
     A: Air<SymbolicAirBuilder<F>>,
 {
-    get_symbolic_constraints(air)
+    get_symbolic_constraints(air, num_public_values)
         .iter()
         .map(|c| c.degree_multiple())
         .max()
         .unwrap_or(0)
 }
 
-#[instrument(name = "evalute constraints symbolically", skip_all, level = "debug")]
-pub fn get_symbolic_constraints<F, A>(air: &A) -> Vec<SymbolicExpression<F>>
+#[instrument(name = "evaluate constraints symbolically", skip_all, level = "debug")]
+pub fn get_symbolic_constraints<F, A>(
+    air: &A,
+    num_public_values: usize,
+) -> Vec<SymbolicExpression<F>>
 where
     F: Field,
     A: Air<SymbolicAirBuilder<F>>,
 {
-    let mut builder = SymbolicAirBuilder::new(air.width());
+    let mut builder = SymbolicAirBuilder::new(air.width(), num_public_values);
     air.eval(&mut builder);
     builder.constraints()
 }
@@ -53,11 +56,12 @@ where
 /// An `AirBuilder` for evaluating constraints symbolically, and recording them for later use.
 pub struct SymbolicAirBuilder<F: Field> {
     main: RowMajorMatrix<SymbolicVariable<F>>,
+    public_values: Vec<F>,
     constraints: Vec<SymbolicExpression<F>>,
 }
 
 impl<F: Field> SymbolicAirBuilder<F> {
-    pub(crate) fn new(width: usize) -> Self {
+    pub(crate) fn new(width: usize, num_public_values: usize) -> Self {
         let values = [false, true]
             .into_iter()
             .flat_map(|is_next| {
@@ -70,6 +74,8 @@ impl<F: Field> SymbolicAirBuilder<F> {
             .collect();
         Self {
             main: RowMajorMatrix::new(values, width),
+            // TODO replace zeros once we have SymbolicExpression::PublicValue
+            public_values: vec![F::zero(); num_public_values],
             constraints: vec![],
         }
     }
@@ -107,5 +113,11 @@ impl<F: Field> AirBuilder for SymbolicAirBuilder<F> {
 
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
         self.constraints.push(x.into());
+    }
+}
+
+impl<F: Field> AirBuilderWithPublicValues for SymbolicAirBuilder<F> {
+    fn public_values(&self) -> &[Self::F] {
+        self.public_values.as_slice()
     }
 }

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -46,6 +46,7 @@ where
     let g_subgroup = SC::Val::two_adic_generator(*degree_bits);
 
     challenger.observe(commitments.trace.clone());
+    challenger.observe_slice(public_values);
     let alpha: SC::Challenge = challenger.sample_ext_element();
     challenger.observe(commitments.quotient_chunks.clone());
     let zeta: SC::Challenge = challenger.sample_ext_element();

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -18,12 +18,13 @@ pub fn verify<SC, A>(
     air: &A,
     challenger: &mut SC::Challenger,
     proof: &Proof<SC>,
+    public_values: &Vec<SC::Val>,
 ) -> Result<(), VerificationError>
 where
     SC: StarkGenericConfig,
-    A: Air<SymbolicAirBuilder<SC::Val>> + for<'a> Air<VerifierConstraintFolder<'a, SC::Challenge>>,
+    A: Air<SymbolicAirBuilder<SC::Val>> + for<'a> Air<VerifierConstraintFolder<'a, SC>>,
 {
-    let log_quotient_degree = get_log_quotient_degree::<SC::Val, A>(air);
+    let log_quotient_degree = get_log_quotient_degree::<SC::Val, A>(air, public_values.len());
     let quotient_degree = 1 << log_quotient_degree;
 
     let Proof {
@@ -110,6 +111,7 @@ where
             local: &opened_values.trace_local,
             next: &opened_values.trace_next,
         },
+        public_values,
         is_first_row,
         is_last_row,
         is_transition,

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -1,0 +1,170 @@
+use std::borrow::Borrow;
+
+use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
+use p3_baby_bear::{BabyBear, DiffusionMatrixBabybear};
+use p3_challenger::DuplexChallenger;
+use p3_commit::ExtensionMmcs;
+use p3_dft::Radix2DitParallel;
+use p3_field::extension::BinomialExtensionField;
+use p3_field::{AbstractField, Field, PrimeField64};
+use p3_fri::{FriConfig, TwoAdicFriPcs};
+use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::{Matrix, MatrixRowSlices};
+use p3_merkle_tree::FieldMerkleTreeMmcs;
+use p3_poseidon2::Poseidon2;
+use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+use p3_uni_stark::{prove, verify, StarkConfig};
+use p3_util::log2_ceil_usize;
+use rand::thread_rng;
+
+/// For testing the public values feature
+
+pub struct FibonacciAir {}
+
+impl<F> BaseAir<F> for FibonacciAir {
+    fn width(&self) -> usize {
+        NUM_FIBONACCI_COLS
+    }
+}
+
+impl<AB: AirBuilderWithPublicValues> Air<AB> for FibonacciAir {
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let pis = builder.public_values();
+
+        let a = pis[0];
+        let b = pis[1];
+        let x = pis[2];
+
+        let local: &FibonacciRow<AB::Var> = main.row_slice(0).borrow();
+        let next: &FibonacciRow<AB::Var> = main.row_slice(1).borrow();
+
+        let mut when_first_row = builder.when_first_row();
+
+        when_first_row.assert_eq(local.left, a);
+        when_first_row.assert_eq(local.right, b);
+
+        let mut when_transition = builder.when_transition();
+
+        // a' <- b
+        when_transition.assert_eq(local.right, next.left);
+
+        // b' <- a + b
+        when_transition.assert_eq(local.left + local.right, next.right);
+
+        builder.when_last_row().assert_eq(local.right, x);
+    }
+}
+
+pub fn generate_trace_rows<F: PrimeField64>(a: u64, b: u64, n: usize) -> RowMajorMatrix<F> {
+    assert!(n.is_power_of_two());
+
+    let mut trace =
+        RowMajorMatrix::new(vec![F::zero(); n * NUM_FIBONACCI_COLS], NUM_FIBONACCI_COLS);
+
+    let (prefix, rows, suffix) = unsafe { trace.values.align_to_mut::<FibonacciRow<F>>() };
+    assert!(prefix.is_empty(), "Alignment should match");
+    assert!(suffix.is_empty(), "Alignment should match");
+    assert_eq!(rows.len(), n);
+
+    rows[0] = FibonacciRow::new(F::from_canonical_u64(a), F::from_canonical_u64(b));
+
+    for i in 1..n {
+        rows[i].left = rows[i - 1].right;
+        rows[i].right = rows[i - 1].left + rows[i - 1].right;
+    }
+
+    trace
+}
+
+const NUM_FIBONACCI_COLS: usize = 2;
+
+pub struct FibonacciRow<F> {
+    pub left: F,
+    pub right: F,
+}
+
+impl<F> FibonacciRow<F> {
+    fn new(left: F, right: F) -> FibonacciRow<F> {
+        FibonacciRow { left, right }
+    }
+}
+
+impl<F> Borrow<FibonacciRow<F>> for [F] {
+    fn borrow(&self) -> &FibonacciRow<F> {
+        debug_assert_eq!(self.len(), NUM_FIBONACCI_COLS);
+        let (prefix, shorts, suffix) = unsafe { self.align_to::<FibonacciRow<F>>() };
+        debug_assert!(prefix.is_empty(), "Alignment should match");
+        debug_assert!(suffix.is_empty(), "Alignment should match");
+        debug_assert_eq!(shorts.len(), 1);
+        &shorts[0]
+    }
+}
+
+type Val = BabyBear;
+type Perm = Poseidon2<Val, DiffusionMatrixBabybear, 16, 7>;
+type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+type ValMmcs =
+    FieldMerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompress, 8>;
+type Challenge = BinomialExtensionField<Val, 4>;
+type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+type Challenger = DuplexChallenger<Val, Perm, 16>;
+type Dft = Radix2DitParallel;
+type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
+type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+
+#[test]
+fn test_public_value() {
+    let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut thread_rng());
+    let hash = MyHash::new(perm.clone());
+    let compress = MyCompress::new(perm.clone());
+    let val_mmcs = ValMmcs::new(hash, compress);
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+    let dft = Dft {};
+    let trace = generate_trace_rows::<Val>(0, 1, 1 << 3);
+    let fri_config = FriConfig {
+        log_blowup: 2,
+        num_queries: 28,
+        proof_of_work_bits: 8,
+        mmcs: challenge_mmcs,
+    };
+    let pcs = Pcs::new(log2_ceil_usize(trace.height()), dft, val_mmcs, fri_config);
+    let config = MyConfig::new(pcs);
+    let mut challenger = Challenger::new(perm.clone());
+    let pis = vec![
+        BabyBear::from_canonical_u64(0),
+        BabyBear::from_canonical_u64(1),
+        BabyBear::from_canonical_u64(21),
+    ];
+    let proof = prove(&config, &FibonacciAir {}, &mut challenger, trace, &pis);
+    let mut challenger = Challenger::new(perm);
+    verify(&config, &FibonacciAir {}, &mut challenger, &proof, &pis).expect("verification failed");
+}
+
+#[test]
+#[should_panic(expected = "assertion `left == right` failed: constraints had nonzero value")]
+fn test_incorrect_public_value() {
+    let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut thread_rng());
+    let hash = MyHash::new(perm.clone());
+    let compress = MyCompress::new(perm.clone());
+    let val_mmcs = ValMmcs::new(hash, compress);
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+    let dft = Dft {};
+    let fri_config = FriConfig {
+        log_blowup: 2,
+        num_queries: 28,
+        proof_of_work_bits: 8,
+        mmcs: challenge_mmcs,
+    };
+    let trace = generate_trace_rows::<Val>(0, 1, 1 << 3);
+    let pcs = Pcs::new(log2_ceil_usize(trace.height()), dft, val_mmcs, fri_config);
+    let config = MyConfig::new(pcs);
+    let mut challenger = Challenger::new(perm.clone());
+    let pis = vec![
+        BabyBear::from_canonical_u64(0),
+        BabyBear::from_canonical_u64(1),
+        BabyBear::from_canonical_u64(123_123), // incorrect result
+    ];
+    prove(&config, &FibonacciAir {}, &mut challenger, trace, &pis);
+}

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -108,7 +108,7 @@ fn test_prove_baby_bear() -> Result<(), VerificationError> {
 
     let mut challenger = Challenger::new(perm.clone());
     let trace = random_valid_trace::<Val>(HEIGHT);
-    let proof = prove::<MyConfig, _>(&config, &MulAir, &mut challenger, trace);
+    let proof = prove::<MyConfig, _>(&config, &MulAir, &mut challenger, trace, &vec![]);
 
     let serialized_proof = postcard::to_allocvec(&proof).expect("unable to serialize proof");
     tracing::debug!("serialized_proof len: {} bytes", serialized_proof.len());
@@ -117,7 +117,13 @@ fn test_prove_baby_bear() -> Result<(), VerificationError> {
         postcard::from_bytes(&serialized_proof).expect("unable to deserialize proof");
 
     let mut challenger = Challenger::new(perm);
-    verify(&config, &MulAir, &mut challenger, &deserialized_proof)
+    verify(
+        &config,
+        &MulAir,
+        &mut challenger,
+        &deserialized_proof,
+        &vec![],
+    )
 }
 
 #[test]


### PR DESCRIPTION
This is a first step towards supporting public instance data in Valida. 

We add an `AirBuilderWithPublicValues' trait, following
 https://github.com/Plonky3/Plonky3/commit/2edbd19b0482decf20443e90c78f375672da8241

